### PR TITLE
Remove Double Legacy

### DIFF
--- a/code/components/net/src/NetLibrary.cpp
+++ b/code/components/net/src/NetLibrary.cpp
@@ -635,19 +635,7 @@ void NetLibrary::ConnectToServer(const net::PeerAddress& address)
 
 				return;
 			}
-
-			if (!node["sH"].IsDefined())
-			{
-				// Server did not send a scripts setting: old server or rival project
-				OnConnectionError("Legacy servers are incompatible with this version of FiveM. Update the server to the latest files from fivem.net");
-				m_connectionState = CS_IDLE;
-				return;
-			}
-			else
-			{
-				Instance<ICoreGameInit>::Get()->ShAllowed = node["sH"].as<bool>(true);
-			}
-
+			
 			m_httpClient->DoGetRequest(fmt::sprintf("https://runtime.fivem.net/policy/shdisable?server=%s_%d", address.GetHost(), address.GetPort()), [=](bool success, const char* data, size_t length)
 			{
 				if (success)


### PR DESCRIPTION
What I removed is what's throwing the secondary legacy server error message, doesn't seem like it needs to be in the code since it already verifies another way.